### PR TITLE
LPD-87006 Accept new fields in customAttachment export

### DIFF
--- a/modules/test/playwright/tests/batch-planner/main/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/main/export.spec.ts
@@ -356,6 +356,7 @@ test('can export as JSON with all field types mapped', async ({
 			},
 			customAttachment: {
 				alternativeText: expect.any(String),
+				extension: expect.any(String),
 				externalReferenceCode: expect.any(String),
 				id: expect.any(Number),
 				link: {
@@ -368,6 +369,7 @@ test('can export as JSON with all field types mapped', async ({
 					externalReferenceCode: expect.any(String),
 					type: expect.any(String),
 				},
+				size: expect.any(String),
 			},
 			customBoolean: true,
 			customLongText: 'This is a custom LongText field',


### PR DESCRIPTION
## Jira
[LPD-87006](https://liferay.atlassian.net/browse/LPD-87006) — addresses the acceptance failure tracked in [LPD-86078](https://liferay.atlassian.net/browse/LPD-86078).

## Description
The backend export of `customAttachment` in the Data Migration Center now emits two new fields — `extension` and `size` — that the Playwright assertion did not accept. This PR updates `tests/batch-planner/main/export.spec.ts` to accept both.

## Test
From `modules/test/playwright/`:

` npx playwright test --project='batch-planner.main' tests/batch-planner/main/export.spec.ts `

The relevant test is `can export as JSON with all field types mapped` (line 154).

## Before
`can export as JSON with all field types mapped` failed with a deep-equality mismatch:
- Initially: extra `\"extension\": \"png\"` field received but not expected.
- After accepting `extension`: extra `\"size\": \"1 KB\"` field received but not expected at the `customAttachment` level.

Spec result: 7/8 passed, 1 failed.

## After
Both `extension` and `size` are now expected as `expect.any(String)` in the assertion.

Spec result locally on a clean bundle: **8/8 passed (1.7m)**.