### PR TITLE
LPD-87007 Match new report entries ZIP filename without timestamp suffix

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.importReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.importReport.spec.ts
@@ -183,7 +183,7 @@ test(
 			const suggestedFilename = download.suggestedFilename();
 
 			expect(suggestedFilename).toMatch(
-				new RegExp(`^${taskName}-(\\d+)_report_entries\\.zip$`)
+				new RegExp(`^${taskName}_report_entries\\.zip$`)
 			);
 
 			const filePath = getTempFile(suggestedFilename);


### PR DESCRIPTION
## Jira
[LPD-87007](https://liferay.atlassian.net/browse/LPD-87007) — addresses the acceptance failure tracked in [LPD-86969](https://liferay.atlassian.net/browse/LPD-86969).

## Description
The export report entries ZIP is now named without a timestamp suffix (e.g. `MyExport-<uuid>_report_entries.zip` instead of `MyExport-<uuid>-<timestamp>_report_entries.zip`). This PR updates the regex in `tests/export-import-web/main/site.importReport.spec.ts` to match the new filename.

## Test
From `modules/test/playwright/`:

` npx playwright test --project='export-import-web.main' tests/export-import-web/main/site.importReport.spec.ts `

The relevant test is `Can download export report entries CSV @LPD-65208` (line 106).

## Before
`Can download export report entries CSV` failed at the filename regex assertion:

- Expected pattern: `/^MyExport-<uuid>-(\\d+)_report_entries\\.zip$/`
- Received string: `MyExport-<uuid>_report_entries.zip`

Spec result: 0/2 passed before this fix / on dirty local bundle.

## After
The regex is updated to match the new filename without the timestamp.

Spec result locally on a clean bundle: **2/2 passed (33.7s)**.