### PR TITLE
LPD-87009 Remove obsolete fail expectation for masterclass site initializer

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
@@ -51,16 +51,14 @@ const testWithClaritySiteInitializerFF = mergeTests(
 );
 
 [
-	{name: 'com.liferay.site.initializer.masterclass', shouldFail: true},
+	{name: 'com.liferay.site.initializer.masterclass'},
 	{name: 'com.liferay.site.initializer.welcome'},
-].forEach(({name, shouldFail}) => {
+].forEach(({name}) => {
 	test(`Local Staging can be enabled with site initializer ${name}`, async ({
 		apiHelpers,
 		page,
 		stagingPage,
-	}, testInfo) => {
-		testInfo.fail(shouldFail);
-
+	}) => {
 		const site = await apiHelpers.headlessSite.createSite({
 			name,
 			templateKey: name,


### PR DESCRIPTION
## Jira
[LPD-87009](https://liferay.atlassian.net/browse/LPD-87009) — addresses the acceptance failure tracked in [LPD-86081](https://liferay.atlassian.net/browse/LPD-86081).

## Description
The `masterclass` site initializer used to fail to enable Local Staging, so the test marked that expectation as `.fail()`. The underlying behavior now works, so the expectation flipped to \"Expected to fail, but passed\". This PR removes the obsolete `.fail()` expectation in `tests/export-import-web/main/site.siteInitializer.spec.ts`.

## Test
From `modules/test/playwright/`:

` npx playwright test --project='export-import-web.main' tests/export-import-web/main/site.siteInitializer.spec.ts `

The relevant test is `Local Staging can be enabled with site initializer com.liferay.site.initializer.masterclass` (line 57).

## Before
The test failed with `Expected to fail, but passed` — the `.fail()` expectation was stale.

## After
Without the stale `.fail()`, the target test passes cleanly.

Spec result locally on a clean bundle: **target test passes**. Overall 4/5 passed; the one remaining red is `:199 Clarity site initializer` which hit a 300s timeout and is unrelated to this change (not in scope of LPD-86081).