### PR TITLE
LPD-86970 Fix Staging publish template Options locator

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -213,10 +213,7 @@ export class StagingPage {
 	}
 
 	async gotoTemplatePage() {
-		await this.page
-			.getByText('Staging Open Applications')
-			.getByLabel('Options')
-			.click();
+		await this.page.getByLabel('Options', {exact: true}).click();
 		await this.page
 			.getByRole('menuitem', {name: 'Publish Templates'})
 			.click();


### PR DESCRIPTION
## Summary

The 'Staging Open Applications' text never matched any element in the DOM, so the chained 'Options' label inside it never resolved. The portlet config 'Options' kebab is the only element with that aria-label on the staging processes page when staging is enabled, so an exact `getByLabel` match is sufficient.

## Test plan

- [x] `cd modules/test/playwright && yarn test --project=export-import-web.main -g "Staging publish template with smoke"` passes locally