### PR TITLE
LPD-86478 Update editURL for CKEditor 5 inline link form

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page, expect} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
@@ -20,7 +20,6 @@ export class JournalEditArticlePage {
 	readonly changesSavedIndicator: Locator;
 	readonly clearButton: Locator;
 	readonly content: Locator;
-	readonly contentFrame: FrameLocator;
 	readonly defaultTemplateButton: Locator;
 	readonly duplicateButton: Locator;
 	readonly friendlyURLInput: Locator;
@@ -49,9 +48,6 @@ export class JournalEditArticlePage {
 
 		this.clearButton = page.getByRole('button', {name: 'Clear'});
 		this.content = page.getByText('Content', {exact: true});
-		this.contentFrame = page.frameLocator(
-			'internal:role=application[name="Content,"i] >> iframe[title="editor"]'
-		);
 		this.defaultTemplateButton = page.getByRole('button', {
 			name: 'Default Template',
 		});
@@ -294,9 +290,10 @@ export class JournalEditArticlePage {
 	}
 
 	async editURL(title: string, url: string) {
-		await this.contentFrame.getByRole('link', {name: title}).dblclick();
-		await this.page.getByLabel('URL*').fill(url);
-		await this.page.getByLabel('OK').click();
+		await this.page.getByRole('link', {name: title}).click();
+		await this.page.getByRole('button', {name: 'Edit link'}).click();
+		await this.page.getByLabel('Link URL').fill(url);
+		await this.page.getByRole('button', {name: 'Update'}).click();
 	}
 
 	async fillContent(content: string) {


### PR DESCRIPTION
## Summary

The Journal article editor uses CKEditor 5 inline (no iframe), so the `contentFrame` locator never resolved. Edit URL also moved from a modal dialog with 'URL*' and 'OK' to a balloon form with 'Edit link', 'Link URL' and 'Update'.

The unused `contentFrame` field and `FrameLocator` import were removed.

## Test plan

- [x] `cd modules/test/playwright && yarn test --project=export-import-web.main -g "Cannot publish if linked file does not exist"` passes locally