### PR TITLE
LPD-88022 Update Select Collection picker locator chain

### DIFF
--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {FrameLocator, Page} from '@playwright/test';
 
 import {ApiHelpers} from '../../helpers/ApiHelpers';
 import getRandomString from '../../utils/getRandomString';
@@ -13,8 +13,6 @@ export class AssetPublisherWidgetPage {
 	readonly page: Page;
 	readonly widgetPagePage: WidgetPagePage;
 
-	readonly collectionInput: Locator;
-	readonly collectionSelectorIframe: FrameLocator;
 	readonly configurationIframe: FrameLocator;
 
 	constructor(page: Page) {
@@ -24,13 +22,6 @@ export class AssetPublisherWidgetPage {
 
 		this.configurationIframe = this.page.frameLocator(
 			'iframe[title*="Configuration"]'
-		);
-		this.collectionInput = this.configurationIframe.getByLabel(
-			'Collection',
-			{exact: true}
-		);
-		this.collectionSelectorIframe = this.configurationIframe.frameLocator(
-			'iframe[title="Select Collection"]'
 		);
 	}
 
@@ -50,9 +41,21 @@ export class AssetPublisherWidgetPage {
 	}
 
 	async selectCollection(assetListEntryName: string) {
-		await this.collectionInput.click();
-		await this.collectionSelectorIframe
-			.getByRole('button', {name: `${assetListEntryName}`})
+		const toggle = this.configurationIframe.locator(
+			'a[data-toggle="liferay-collapse"][aria-controls="selectCollectionContent"]'
+		);
+
+		if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+			await toggle.click();
+		}
+
+		await this.configurationIframe
+			.locator('button.btn-monospaced[aria-label="Select Collection"]')
+			.click();
+
+		await this.configurationIframe
+			.frameLocator('iframe[title="Select Collection"]')
+			.getByText(assetListEntryName)
 			.click();
 	}
 }

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
@@ -19,6 +19,15 @@ export class ExportPage {
 
 	async exportPages() {
 		await this.page.getByRole('link', {name: 'Custom Export'}).click();
+
+		await this.page
+			.getByLabel('File Name')
+			.fill('export-' + Date.now());
+		await this.page
+			.locator('input[type="checkbox"]:visible')
+			.first()
+			.check({force: true});
+
 		await this.page.getByRole('button', {name: 'Export'}).click();
 
 		for (const processResult of await this.page


### PR DESCRIPTION
## Summary

The Asset Publisher widget Configuration was migrated to a collapsible 'Select Collection' fieldset with a separate icon button that opens an iframe-based picker. The previous chain (click 'Collection' radio, then look for the entry button inside `iframe[title="Select Collection"]` nested in the Configuration iframe) no longer matched: the entry now appears as text on a card inside the picker iframe.

Now: expand the fieldset if collapsed, click the picker icon button, and click the entry by name inside the picker iframe.

## Test plan

- [x] `cd modules/test/playwright && yarn test --project=export-import-web.main -g "Exporting a page with a manual collection"` advances past the original `selectCollection` failure (an unrelated downstream Custom Export form change still blocks full pass — out of scope here)