### PR TITLE
LPD-86968 Assert Export button disabled instead of alert text

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -66,13 +66,7 @@ test(
 
 		await exportImportPage.newExportButton.click();
 
-		await exportImportPage.exportButton.click();
-
-		await expect(
-			exportImportPage.page.getByRole('alert').filter({
-				hasText: 'Please enter a file with a valid file name.',
-			})
-		).toBeVisible();
+		await expect(exportImportPage.exportButton).toBeDisabled();
 	}
 );
 


### PR DESCRIPTION
## Summary

The Custom Export form now keeps the Export button disabled while the required File Name is empty, replacing the previous post-submit 'Please enter a file with a valid file name.' alert. The empty-name guard is unchanged; only the surfacing mechanism is.

## Test plan

- [x] `cd modules/test/playwright && yarn test --project=export-import-web.main -g "cannot export at site level without file name"` passes locally