### PR TITLE
LPD-88403 Fix Staging publish template Options locator

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -213,10 +213,7 @@ export class StagingPage {
 	}
 
 	async gotoTemplatePage() {
-		await this.page
-			.getByText('Staging Open Applications')
-			.getByLabel('Options')
-			.click();
+		await this.page.getByLabel('Options', {exact: true}).click();
 		await this.page
 			.getByRole('menuitem', {name: 'Publish Templates'})
 			.click();


### PR DESCRIPTION
## Jira

[LPD-88403](https://liferay.atlassian.net/browse/LPD-88403) — addresses the acceptance failure tracked in [LPD-86970](https://liferay.atlassian.net/browse/LPD-86970).

## Description

`StagingPage.gotoTemplatePage()` chained `getByText('Staging Open Applications').getByLabel('Options')`, but the "Staging Open Applications" text never existed in the rendered DOM, so the locator never resolved and clicks on the portlet config Options kebab timed out. The kebab is the only element with that `aria-label` on the staging processes page when staging is enabled, so an exact `getByLabel` match suffices.

## Test

From `modules/test/playwright/`:

` npx playwright test --project='export-import-web.main' tests/export-import-web/main/stagingUseCase.spec.ts `

The relevant test is `Staging publish template with smoke` (line 697).

## Before

The test failed with a 90s timeout on `getByText('Staging Open Applications').getByLabel('Options').click()` because no element matched the chained text.

## After

The Options kebab resolves immediately and the test reaches Publish Templates cleanly. Spec target test passes locally (~58s).