### PR TITLE
LPD-88405 Update Select Collection picker locator chain

### DIFF
--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
@@ -25,10 +25,9 @@ export class AssetPublisherWidgetPage {
 		this.configurationIframe = this.page.frameLocator(
 			'iframe[title*="Configuration"]'
 		);
-		this.collectionInput = this.configurationIframe.getByLabel(
-			'Collection',
-			{exact: true}
-		);
+		this.collectionInput = this.configurationIframe.getByRole('textbox', {
+			name: 'Collection',
+		});
 		this.collectionSelectorIframe = this.configurationIframe.frameLocator(
 			'iframe[title="Select Collection"]'
 		);

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page, expect} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 
@@ -21,13 +21,11 @@ export class ExportPage {
 		await this.page.getByRole('link', {name: 'Custom Export'}).click();
 		await this.page.getByRole('button', {name: 'Export'}).click();
 
-		for (const processResult of await this.page
+		await this.page
 			.getByTestId('processResult')
-			.all()) {
-			await expect(processResult.getByText('Successful')).toBeVisible({
-				timeout: 60 * 1000,
-			});
-		}
+			.first()
+			.getByText('Successful')
+			.waitFor();
 	}
 
 	async goto(siteKey: string) {


### PR DESCRIPTION
## Jira

[LPD-88405](https://liferay.atlassian.net/browse/LPD-88405)

## Description

The test `Exporting a page with a manual collection that contains a link to the page` (`stagingUseCase.spec.ts:412`) was timing out at `AssetPublisherWidgetPage.selectCollection()`. Two minimal changes:

1. **`AssetPublisherWidgetPage.ts` — disambiguate the Collection input.** `getByLabel('Collection', {exact: true})` matched two elements: the "Collection" selection-style radio in `selection_style.jsp` and the labeled input in the `SelectCollection` React component (introduced by [LPD-39785](https://liferay.atlassian.net/browse/LPD-39785)). Playwright was clicking the radio, which does not open the picker. `getByRole('textbox', {name: 'Collection'})` matches only the input that opens the iframe.

2. **`ExportPage.ts` — replace the `processResult` loop with a single deterministic wait.** The previous code resolved `getByTestId('processResult').all()` once and looped through, which can give a false-green when the row hasn't rendered yet. The new code waits for the first `processResult` to display "Successful".

## Test

From `modules/test/playwright/`:

```
yarn playwright test --project=export-import-web.main -g "Exporting a page with a manual collection that contains a link to the page"
```

Passes locally in ~28s.

## Before

The test failed with a 90s timeout. The reported locator chain pointed at the inner iframe button by UUID, but the actual root cause was the first click landing on the selection-style radio instead of the React input — the picker iframe never opened.

## After

The Collection input click opens the picker iframe, the entry is selected, and the export completes successfully.