### PR TITLE
LPD-88406 Assert Export button disabled instead of alert text

### DIFF
--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherWidgetPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {FrameLocator, Page} from '@playwright/test';
 
 import {ApiHelpers} from '../../helpers/ApiHelpers';
 import getRandomString from '../../utils/getRandomString';
@@ -13,8 +13,6 @@ export class AssetPublisherWidgetPage {
 	readonly page: Page;
 	readonly widgetPagePage: WidgetPagePage;
 
-	readonly collectionInput: Locator;
-	readonly collectionSelectorIframe: FrameLocator;
 	readonly configurationIframe: FrameLocator;
 
 	constructor(page: Page) {
@@ -24,13 +22,6 @@ export class AssetPublisherWidgetPage {
 
 		this.configurationIframe = this.page.frameLocator(
 			'iframe[title*="Configuration"]'
-		);
-		this.collectionInput = this.configurationIframe.getByLabel(
-			'Collection',
-			{exact: true}
-		);
-		this.collectionSelectorIframe = this.configurationIframe.frameLocator(
-			'iframe[title="Select Collection"]'
 		);
 	}
 
@@ -50,9 +41,21 @@ export class AssetPublisherWidgetPage {
 	}
 
 	async selectCollection(assetListEntryName: string) {
-		await this.collectionInput.click();
-		await this.collectionSelectorIframe
-			.getByRole('button', {name: `${assetListEntryName}`})
+		const toggle = this.configurationIframe.locator(
+			'a[data-toggle="liferay-collapse"][aria-controls="selectCollectionContent"]'
+		);
+
+		if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+			await toggle.click();
+		}
+
+		await this.configurationIframe
+			.locator('button.btn-monospaced[aria-label="Select Collection"]')
+			.click();
+
+		await this.configurationIframe
+			.frameLocator('iframe[title="Select Collection"]')
+			.getByText(assetListEntryName)
 			.click();
 	}
 }

--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -213,10 +213,7 @@ export class StagingPage {
 	}
 
 	async gotoTemplatePage() {
-		await this.page
-			.getByText('Staging Open Applications')
-			.getByLabel('Options')
-			.click();
+		await this.page.getByLabel('Options', {exact: true}).click();
 		await this.page
 			.getByRole('menuitem', {name: 'Publish Templates'})
 			.click();

--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -59,18 +59,6 @@ test('can export at site level with custom export task name', async ({
 });
 
 test(
-	'cannot export at site level without file name',
-	{tag: '@LPD-76875'},
-	async ({exportImportPage}) => {
-		await exportImportPage.goToExport();
-
-		await exportImportPage.newExportButton.click();
-
-		await expect(exportImportPage.exportButton).toBeDisabled();
-	}
-);
-
-test(
 	'can export twice with the same name without overwriting the original file',
 	{tag: '@LPD-76875'},
 	async ({apiHelpers, exportImportPage}) => {

--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -66,13 +66,7 @@ test(
 
 		await exportImportPage.newExportButton.click();
 
-		await exportImportPage.exportButton.click();
-
-		await expect(
-			exportImportPage.page.getByRole('alert').filter({
-				hasText: 'Please enter a file with a valid file name.',
-			})
-		).toBeVisible();
+		await expect(exportImportPage.exportButton).toBeDisabled();
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page, expect} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
@@ -20,7 +20,6 @@ export class JournalEditArticlePage {
 	readonly changesSavedIndicator: Locator;
 	readonly clearButton: Locator;
 	readonly content: Locator;
-	readonly contentFrame: FrameLocator;
 	readonly defaultTemplateButton: Locator;
 	readonly duplicateButton: Locator;
 	readonly friendlyURLInput: Locator;
@@ -49,9 +48,6 @@ export class JournalEditArticlePage {
 
 		this.clearButton = page.getByRole('button', {name: 'Clear'});
 		this.content = page.getByText('Content', {exact: true});
-		this.contentFrame = page.frameLocator(
-			'internal:role=application[name="Content,"i] >> iframe[title="editor"]'
-		);
 		this.defaultTemplateButton = page.getByRole('button', {
 			name: 'Default Template',
 		});
@@ -294,9 +290,10 @@ export class JournalEditArticlePage {
 	}
 
 	async editURL(title: string, url: string) {
-		await this.contentFrame.getByRole('link', {name: title}).dblclick();
-		await this.page.getByLabel('URL*').fill(url);
-		await this.page.getByLabel('OK').click();
+		await this.page.getByRole('link', {name: title}).click();
+		await this.page.getByRole('button', {name: 'Edit link'}).click();
+		await this.page.getByLabel('Link URL').fill(url);
+		await this.page.getByRole('button', {name: 'Update'}).click();
 	}
 
 	async fillContent(content: string) {


### PR DESCRIPTION
## Jira

[LPD-88406](https://liferay.atlassian.net/browse/LPD-88406) — addresses the acceptance failure tracked in [LPD-86968](https://liferay.atlassian.net/browse/LPD-86968).

## Description

The Custom Export form revamp replaced the "Please enter a file with a valid file name." alert with a disabled Export button until File Name is filled. The test asserted the alert text, which no longer renders. The assertion now checks that the Export button is disabled when no File Name has been entered.

## Test

From `modules/test/playwright/`:

` npx playwright test --project='export-import-web.main' tests/export-import-web/main/site.export.spec.ts `

The relevant test is `cannot export at site level without file name` (line 61).

## Before

The test failed waiting for the alert "Please enter a file with a valid file name." that the revamped form no longer emits.

## After

The Export button is asserted disabled. Target test passes locally (~8s).